### PR TITLE
change public and user share drivers to jsoncs3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,8 +72,8 @@ services:
       OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-info}
       OCIS_LOG_COLOR: "${OCIS_LOG_COLOR:-false}"
       PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
-      SHARING_USER_DRIVER: "cs3"
-      SHARING_PUBLIC_DRIVER: "cs3"
+      SHARING_USER_DRIVER: "jsoncs3"
+      SHARING_PUBLIC_DRIVER: "jsoncs3"
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
       FRONTEND_OCS_ENABLE_DENIALS: "true"


### PR DESCRIPTION
# Desciption

Changed both sharing drivers to `jsoncs3` to unblock further updates

## Migration

I have run:

- [ ] `ocis migrate shares --from cs3 --to jsoncs3`

- [ ] `ocis migrate publicshares --from cs3 --to jsoncs3`

The shares are still available after switching the config.